### PR TITLE
Improve batch command handling and WinExec fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ You can also keep the asm code by running it like this:
 * ECHO
 * GOTO
 * :LABEL
+* All other batch commands are implemented via WinExec fallback and will not get the better performance.
 
 ## Supported OSes
 
@@ -45,4 +46,5 @@ You can also keep the asm code by running it like this:
 * Add Linux support (medium priority)
 * Add macOS support (low priority)
 * Support all batch features (high priority)
-* Properly handle `@echo off`/`@echo on` instead of ignoring them (medium priority)
+* Properly handle `@echo off`/`@echo on` instead of ignoring them (low priority)
+* Ability to compile itself (high priority)

--- a/test/test.bat
+++ b/test/test.bat
@@ -2,16 +2,11 @@
 
 rem This is a remark
 :: This is a broken label
+echo Hello, world!
+goto type_license
 
-echo Hello world!
-echo.
+:type_license
 
-:done
-
-echo Almost done!
-goto finally_done
-
-:finally_done
-
-echo Done!
+type ..\LICENSE
+pause >nul
 exit /b


### PR DESCRIPTION
Enhanced the compiler to handle all unrecognized batch commands via a WinExec fallback, generating appropriate assembly code. Updated README to document this behavior and adjusted test.bat to demonstrate new command handling.

**Describe the pull request**
A clear and concise description of what the pull request does.

**Checklist**
I made sure that...

- [x] All checks pass
- [x] There are no syntax errors
- [x] The PR is mergeable
- [x] I read [CONTRIBUTING.md](https://github.com/benja2998/compiler.bat/blob/main/CONTRIBUTING.md) and followed the guidelines

