### PR TITLE
Refactor compiler to use hash utility and improve output handling

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,9 +19,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install dependencies
-        run: sudo apt-get update && sudo apt-get install zip tar wget -y
+        run: sudo apt-get update && sudo apt-get install zip tar wget git -y
 
-      - name: Get short commit hash
+      - name: Get commit hash
         id: get_commit
         run: echo "COMMIT_HASH=$(git rev-parse HEAD)" >> $GITHUB_ENV
 

--- a/src/lib/hash.bat
+++ b/src/lib/hash.bat
@@ -1,0 +1,20 @@
+@echo off
+setlocal enabledelayedexpansion
+
+echo "%~1" > "%TEMP%\temp.txt"
+certutil -hashfile "%TEMP%\temp.txt" SHA256 > "%TEMP%\temp_hash.txt"
+
+set count=0
+for /f "delims=" %%a in ('type %TEMP%\temp_hash.txt') do (
+    set /a count+=1
+    if !count! equ 2 (
+        set "hash=%%a"
+    )
+)
+
+set "hash=!hash: =!"
+set "hash=l!hash!"
+set "hash=!hash:"=!"
+
+echo !hash!> "%TEMP%\hash.txt"
+exit /b


### PR DESCRIPTION
Introduced src/lib/hash.bat to centralize SHA256 hashing logic, replacing inline hash code in compiler.bat. Updated compiler.bat to prompt for output executable name, enforce .exe extension, and consistently use the new hash utility. Improved output file handling and cleaned up temporary file management. Minor updates to release workflow to ensure git is installed and clarify commit hash step.

**Describe the pull request**
A clear and concise description of what the pull request does.

**Checklist**
I made sure that...

- [x] All checks pass
- [x] There are no syntax errors
- [x] The PR is mergeable
- [x] I read [CONTRIBUTING.md](https://github.com/benja2998/compiler.bat/blob/main/CONTRIBUTING.md) and followed the guidelines

