### PR TITLE
Add invalid command test and improve benchmarking

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,5 +21,10 @@ test3:
 	clear
 	batch-compiler -o test.exe -i examples\vars.bat
 
+test4:
+	cargo install --path .
+	clear
+	batch-compiler -o test.exe -i examples\invalid_command.bat
+
 clean:
 	cargo clean

--- a/benchmark.bat
+++ b/benchmark.bat
@@ -2,7 +2,7 @@
 setlocal enabledelayedexpansion
 
 rem Get test selection
-set /p "testnum=Enter test number (1-3): "
+set /p "testnum=Enter test number (1-4): "
 
 if %testnum%==1 (
    set "testfile=hello"
@@ -10,24 +10,43 @@ if %testnum%==1 (
    set "testfile=labels"
 ) else if %testnum%==3 (
    set "testfile=vars"
+) else if %testnum%==4 (
+   set "testfile=invalid_command"
 ) else (
    echo Invalid test number
    exit /b 1
 )
 
+set /p "iter=Enter number of iterations: "
+
+if "%iter%"=="" (
+    echo No iterations specified, defaulting to 10.
+    set "iter=10"
+)
+
 make test%testnum%
 cls
 
-echo Benchmarking %testfile% (10 iterations)...
+echo Benchmarking %testfile% (%iter% iterations)...
 echo ---------------------------
 
-rem Run original 10 times and get average
-for /f "tokens=*" %%a in ('powershell -command "$times=@(); 1..10|foreach{$times+=(measure-command {.\\examples\\%testfile%.bat}).TotalMilliseconds}; $avg=$times|measure-object -average|select-object -expand average; [math]::round($avg,3).tostring('0.000', [globalization.cultureinfo]::invariantculture)"') do (
+rem Run original %iter% times and get average
+for /f "tokens=*" %%a in ('powershell -command "$times=@(); 1..%iter%|foreach{$times+=(measure-command {.\\examples\\%testfile%.bat}).TotalMilliseconds}; $avg=$times|measure-object -average|select-object -expand average; [math]::round($avg,3).tostring('0.000', [globalization.cultureinfo]::invariantculture)"') do (
     set "original_avg=%%a"
 )
 
-rem Run compiled 10 times and get average
-for /f "tokens=*" %%a in ('powershell -command "$times=@(); 1..10|foreach{$times+=(measure-command {.\\test.exe}).TotalMilliseconds}; $avg=$times|measure-object -average|select-object -expand average; [math]::round($avg,3).tostring('0.000', [globalization.cultureinfo]::invariantculture)"') do (
+rem Run compiled %iter% times and get average
+for /f "tokens=*" %%a in ('powershell -command "$times=@(); 1..%iter%|foreach{$times+=(measure-command {.\\test.exe}).TotalMilliseconds}; $avg=$times|measure-object -average|select-object -expand average; [math]::round($avg,3).tostring('0.000', [globalization.cultureinfo]::invariantculture)"') do (
+    set "compiled_avg=%%a"
+)
+
+rem Remove .* from average values
+
+for /f "tokens=1 delims=." %%a in ("%original_avg%") do (
+    set "original_avg=%%a"
+)
+
+for /f "tokens=1 delims=." %%a in ("%compiled_avg%") do (
     set "compiled_avg=%%a"
 )
 
@@ -39,9 +58,5 @@ for /f "tokens=*" %%a in ('powershell -command "[math]::round([double]%original_
 echo Original Average: %original_avg% ms
 echo Compiled Average: %compiled_avg% ms
 echo.
-if %compiled_avg% lss %original_avg% (
-    echo The compiled exe is %speed_ratio% times faster
-) else (
-    echo The compiled exe is %speed_ratio% times slower
-)
+echo The compiled version is %speed_ratio% times the speed of the original script
 echo ---------------------------

--- a/examples/invalid_command.bat
+++ b/examples/invalid_command.bat
@@ -1,0 +1,4 @@
+@echo off
+
+echo Running an invalid command...
+this_is_not_a_valid_command

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -133,7 +133,7 @@ pub fn compile(statements: &[Statement], output_filename: &str, input_filename: 
 
                 let mut string_to_write = format!(
                     r#"
-    l{} db "{}", 0
+    l{} db "cmd /c @{}", 0
 "#,
                     hash_str, identifier
                 );
@@ -395,7 +395,7 @@ fn compile_phase_2(statements: &[Statement], output_filename: &str)
 
                 let hash_str = format!("{:x}", hash);
 
-                let mut string_to_write = format!(
+                let string_to_write = format!(
                     r#"
 sub rsp,72
 xor rcx,rcx


### PR DESCRIPTION
Added examples/invalid_command.bat to test handling of invalid commands. Updated Makefile and benchmark.bat to support the new test and allow configurable iteration counts. Modified src/compile.rs to prefix commands with 'cmd /c @' for improved execution consistency.

**Describe the pull request**
A clear and concise description of what the pull request does.

**Checklist**
I made sure that...

- [x] All checks pass
- [x] There are no syntax errors
- [x] The PR is mergeable
- [x] I read [CONTRIBUTING.md](https://github.com/benja2998/batch/blob/main/CONTRIBUTING.md) and followed the guidelines

